### PR TITLE
Warn if setup not protected

### DIFF
--- a/zp-core/admin.php
+++ b/zp-core/admin.php
@@ -248,7 +248,7 @@ if (!zp_loggedin()) {
 									'category'		 => gettext('Admin'),
 									'enable'			 => true,
 									'button_text'	 => gettext('Setup » restore scripts'),
-									'formname'		 => 'restore_setup.php',
+									'formname'		 => 'restore_setup',
 									'action'			 => WEBPATH . '/' . ZENFOLDER . '/admin.php?action=restore_setup',
 									'icon'				 => 'images/lock_open.png',
 									'alt'					 => '',
@@ -270,7 +270,7 @@ if (!zp_loggedin()) {
 									'category'		 => gettext('Admin'),
 									'enable'			 => true,
 									'button_text'	 => gettext('Setup » protect scripts'),
-									'formname'		 => 'restore_setup.php',
+									'formname'		 => 'restore_setup',
 									'action'			 => WEBPATH . '/' . ZENFOLDER . '/admin.php?action=protect_setup',
 									'icon'				 => 'images/lock_2.png',
 									'alt'					 => '',
@@ -285,7 +285,7 @@ if (!zp_loggedin()) {
 								'category'		 => gettext('Admin'),
 								'enable'			 => true,
 								'button_text'	 => gettext('Run setup'),
-								'formname'		 => 'run_setup.php',
+								'formname'		 => 'run_setup',
 								'action'			 => WEBPATH . '/' . ZENFOLDER . '/setup.php',
 								'icon'				 => 'images/zp.png',
 								'alt'					 => '',
@@ -602,7 +602,7 @@ if (!zp_loggedin()) {
 									<?php
 								}
 								?>
-								<form name="<?php echo $button['formname']; ?>"	action="<?php echo $button['action']; ?>" class="overview_utility_buttons">
+								<form name="<?php echo $button['formname']; ?>"	id="<?php echo $button['formname']; ?>" action="<?php echo $button['action']; ?>" class="overview_utility_buttons">
 									<?php if (isset($button['XSRFTag']) && $button['XSRFTag']) XSRFToken($button['XSRFTag']); ?>
 									<?php echo $button['hidden']; ?>
 									<div class="buttons tooltip" title="<?php echo html_encode($button['title']); ?>">

--- a/zp-core/zenphoto.package
+++ b/zp-core/zenphoto.package
@@ -196,7 +196,7 @@ zp-core/images/warn.png
 zp-core/images/wheel.png
 zp-core/images/zen-logo-light.png
 zp-core/images/zen-logo.png
-zp-core/images/Zp.png
+zp-core/images/zp.png
 zp-core/images/zp_gold.png
 zp-core/images/strengths
 zp-core/images/strengths/strength0.png

--- a/zp-core/zp-extensions/site_upgrade.php
+++ b/zp-core/zp-extensions/site_upgrade.php
@@ -113,7 +113,7 @@ switch (OFFSET_PATH) {
 									'category'		 => gettext('Admin'),
 									'enable'			 => true,
 									'button_text'	 => gettext('Site » test mode'),
-									'formname'		 => 'site_upgrade.php',
+									'formname'		 => 'site_upgrade',
 									'action'			 => WEBPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER . '/site_upgrade/site_upgrade.php',
 									'icon'				 => 'images/lock_open.png',
 									'title'				 => gettext('Make the site available for viewing administrators only.'),
@@ -128,7 +128,7 @@ switch (OFFSET_PATH) {
 									'category'		 => gettext('Admin'),
 									'enable'			 => true,
 									'button_text'	 => gettext('Site » open'),
-									'formname'		 => 'site_upgrade.php',
+									'formname'		 => 'site_upgrade',
 									'action'			 => WEBPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER . '/site_upgrade/site_upgrade.php',
 									'icon'				 => 'images/lock.png',
 									'title'				 => gettext('Make site available for viewing.'),
@@ -136,6 +136,18 @@ switch (OFFSET_PATH) {
 									'hidden'			 => '<input type="hidden" name="siteState" value="open" />',
 									'rights'			 => ADMIN_RIGHTS
 					);
+					list($diff, $needs) = checkSignature(false);
+					if (zpFunctions::hasPrimaryScripts() && empty($needs)) {
+						?>
+						<script type="text/javascript">
+							window.onload = function() {
+								$('#site_upgrade').submit(function(event) {
+									return confirm('<?php echo gettext('You should protect your setup scripts first.'); ?>');
+								})
+							}
+						</script>
+						<?php
+					}
 					break;
 				default:
 					$buttons[] = array(


### PR DESCRIPTION
The site » open button will now warn if you have not protected your
setup scripts.
