### PR TITLE
combat some theme issues

### DIFF
--- a/npgCore/extensions/themeSwitcher.php
+++ b/npgCore/extensions/themeSwitcher.php
@@ -177,8 +177,9 @@ class themeSwitcher {
 				$reloc .= '?themeSwitcher=%t';
 			}
 			$theme = $_gallery->getCurrentTheme();
+			/* Note inline styles needed to override some theme javascript issues */
 			?>
-			<div class="themeSwitcherMenuMain themeSwitcherControl">
+			<div class="themeSwitcherMenuMain themeSwitcherControl" style="position: fixed; z-index: 90001; left: 0px; top: 0px; padding-top: 5px; padding-left: 5px;">
 				<a onclick="$('.themeSwitcherControl').toggle();" title="<?php echo gettext('Switch themes'); ?>" style="text-decoration: none;" >
 					<span class="themeSwitcherMenu">
 						<?php echo MENU_SYMBOL; ?>

--- a/npgCore/global-definitions.php
+++ b/npgCore/global-definitions.php
@@ -1,7 +1,7 @@
 <?php
 
 Define('PHP_MIN_VERSION', '5.6');
-Define('PHP_MIN_SUPPORTED_VERSION', '7.2');
+Define('PHP_MIN_SUPPORTED_VERSION', '7.3');
 Define('PHP_DESIRED_VERSION', '7.4');
 
 if (version_compare(PHP_VERSION, PHP_MIN_VERSION, '<')) {

--- a/npgCore/template-functions.php
+++ b/npgCore/template-functions.php
@@ -77,16 +77,17 @@ function adminToolbox() {
 			</script>
 			<?php
 		}
+		/* Note inline styles needed to override some theme javascript issues */
 		?>
-		<div id="admin_tb" style="zindex: 90001">
-			<a onclick="$('#admin_tb_data').toggle();" title="<?php echo gettext('Logged in as') . ' ' . $name; ?>" style="text-decoration: none;">
+		<div id="admin_tb" style="right: 0px;	 width: 23px; margin-right: 10px; z-index: 90001;">
+			<a onclick="$('#admin_tb_data').toggle();" title="<?php echo gettext('Logged in as') . ' ' . $name; ?>">
 				<span class="adminGear">
 					<?php echo GEAR_SYMBOL; ?>
 				</span>
 			</a>
 		</div>
 		<div id="admin_tb_data" style="display: none;">
-			<ul style="list-style-type: none;" >
+			<ul>
 				<?php
 				if (npg_loggedin(OVERVIEW_RIGHTS)) {
 					?>

--- a/npgCore/template-functions.php
+++ b/npgCore/template-functions.php
@@ -79,7 +79,7 @@ function adminToolbox() {
 		}
 		/* Note inline styles needed to override some theme javascript issues */
 		?>
-		<div id="admin_tb" style="right: 0px;	 width: 23px; margin-right: 10px; z-index: 90001;">
+		<div id="admin_tb" style="position: fixed; right: 0px;	width: 23px; margin-right: 10px; z-index: 90001;">
 			<a onclick="$('#admin_tb_data').toggle();" title="<?php echo gettext('Logged in as') . ' ' . $name; ?>">
 				<span class="adminGear">
 					<?php echo GEAR_SYMBOL; ?>
@@ -4585,7 +4585,7 @@ function policySubmitButton($buttonText, $buttonClass = NULL, $buttonExtra = NUL
 		<span class="policy_acknowledge_check_box">
 			<input id="GDPR_acknowledge" type="checkbox" name="policy_acknowledge" onclick="$(this).parent().next().show();
 						 <?php echo $linked; ?>
-							$(this).parent().hide();" value="<?php echo md5(getUserID() . getOption('GDPR_cookie')); ?>">
+					$(this).parent().hide();" value="<?php echo md5(getUserID() . getOption('GDPR_cookie')); ?>">
 						 <?php
 						 echo sprintf(get_language_string(getOption('GDPR_text')), getOption('GDPR_URL'));
 						 ?>

--- a/npgCore/toolbox.css
+++ b/npgCore/toolbox.css
@@ -17,7 +17,7 @@ Default admin toolbox css
 	padding-left: 5px !important;
 	margin-right: 10px;
 }
-#admin_tb_data{
+#admin_tb_data {
 	display: none;
 	position: fixed;
 	top: 0px;
@@ -34,6 +34,10 @@ Default admin toolbox css
 	font: Arial, "Helvetica Neue", Helvetica, sans-serif;
 }
 
+#admin_tb_data ul {
+	list-style-type: none;
+}
+
 #admin_tb h3 {
 	font-weight: normal;
 	color: #999;
@@ -47,6 +51,9 @@ Default admin toolbox css
 	color: #036;
 }
 
+#admin_tb a {
+	text-decoration: none;
+}
 #admin_tb a:hover {
 	cursor: pointer;
 	text-decoration: none;


### PR DESCRIPTION
Some themes are somehow overriding or suppressing themeswitcher and toolbox css settings. This update places the critical items into inline styles on the DIVs.