### PR TITLE
fixes to replaceSCriptPath

### DIFF
--- a/npgCore/functions-basic.php
+++ b/npgCore/functions-basic.php
@@ -1062,14 +1062,14 @@ function getOptionList() {
  * a clone. SERVERPATH is the path to the clone installation and will not be the same
  * as the script path to the symLinked files.
  *
- * This function deals with the situation and returns the relative path in all cases
+ * This function deals with the situation and returns the relative path
  *
  * @param string $file
  * @return string the relative path to the file
  */
 function replaceScriptPath($file, $replace = '') {
 	$file = str_replace('\\', '/', $file);
-	return trim(preg_replace('~^(' . SERVERPATH . '|' . SCRIPTPATH . ')~i', $replace, $file), '/');
+	return trim(preg_replace('~^(' . SCRIPTPATH . '|' . SERVERPATH . ')~i', $replace, $file), '/');
 }
 
 /**

--- a/npgCore/utilities/installation_analysis.php
+++ b/npgCore/utilities/installation_analysis.php
@@ -333,7 +333,7 @@ echo '</head>';
 							<li>
 								<?php
 								$authority = new ReflectionClass(get_class($_authority));
-								$file = trim(str_replace(SCRIPTPATH, '', str_replace('\\', '/', $authority->getFileName())), '/');
+								$file = replaceScriptPath($authority->getFileName());
 								echo gettext('Authentication authority: ') . '<strong>' . $file . '</strong>';
 								?>
 							</li>
@@ -478,8 +478,8 @@ echo '</head>';
 	</div>
 </body>
 <script type="text/javascript">
-								var height = Math.floor(($('#overview_left').height() - $('.overview-list-h3').height() * 2) / 2 - 8);
-								$('.overview_list').height(height);
+										var height = Math.floor(($('#overview_left').height() - $('.overview-list-h3').height() * 2) / 2 - 8);
+										$('.overview_list').height(height);
 </script>
 
 <?php

--- a/npgCore/version.php
+++ b/npgCore/version.php
@@ -1,4 +1,4 @@
 <?php
 // This file contains version info only and is automatically updated. DO NOT EDIT.
-define('NETPHOTOGRAPHICS_VERSION', '2.00.13.09.02');
+define('NETPHOTOGRAPHICS_VERSION', '2.00.13.09.03');
 ?>


### PR DESCRIPTION
now handles the case where the clone is located lower in the directory structure than the master.