### PR TITLE
Update lib-i18n.php

### DIFF
--- a/npgCore/lib-i18n.php
+++ b/npgCore/lib-i18n.php
@@ -415,9 +415,9 @@ class i18n {
 	 */
 	static function htmlLanguageCode($locale = NULL) {
 		if ($locale) {
-			echo ' lang="' . str_replace('_', '-', $locale);
+			echo ' lang="' . str_replace('_', '-', $locale) . '"';
 		} else if ($lang = self::getUserLocale('-')) {
-			echo ' lang="' . $lang;
+			echo ' lang="' . $lang . '"';
 		}
 	}
 


### PR DESCRIPTION
Fixed malformed lang attribute generation in i18n::htmlLanguageCode() by adding the missing closing quotation mark, correcting invalid markup.